### PR TITLE
Make `get_raw_bytes` public

### DIFF
--- a/src/onion/v3/onion.rs
+++ b/src/onion/v3/onion.rs
@@ -13,7 +13,7 @@ use crate::utils::BASE32_ALPHA;
 /// 32 public key bytes + 2 bytes of checksum = 34
 /// (in onion address v3 there is one more byte - version eq to 3)
 /// Checksum is hardcoded in order not to recompute it.
-/// 
+///
 /// This variable denotates byte length of OnionAddressV3.
 pub const TORV3_ONION_ADDRESS_LENGTH_BYTES: usize = 34;
 
@@ -110,7 +110,7 @@ impl FromStr for OnionAddressV3 {
     type Err = OnionAddressParseError;
 
     /// from_str parses OnionAddressV3 from string.
-    /// 
+    ///
     /// Please note that it accepts address *without* .onion only.
     fn from_str(raw_onion_address: &str) -> Result<Self, Self::Err> {
         if raw_onion_address.as_bytes().len() != 56 {

--- a/src/onion/v3/onion.rs
+++ b/src/onion/v3/onion.rs
@@ -77,7 +77,7 @@ impl OnionAddressV3 {
     }
 
     #[inline]
-    fn get_raw_bytes(&self) -> [u8; 35] {
+    pub fn get_raw_bytes(&self) -> [u8; 35] {
         let mut buf = [0u8; 35];
         buf[..34].clone_from_slice(&self.0);
         buf[34] = 3;


### PR DESCRIPTION
In order to use the onion address logic from the `torut` library with other libraries we would like to have access to the full 35 bytes of the address. We have this functionality already, make it public so others can use it.

Done as part of wiring together an [application](https://github.com/tcharding/ping-pong) that uses [rust-libp2p](https://github.com/tcharding/rust-libp2p) over Tor. Thanks for writing `torut`, its really nice.