### PR TITLE
[blocked] on replacing OpenSSL with RSA

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["tor", "controller", "tokio", "onion"]
 default = ["serialize", "v2", "v3", "control"]
 serialize = ["serde", "serde_derive", "base32", "base64"]
 control = ["tokio", "rand", "hex", "sha2", "hmac"]
-v2 = ["openssl", "base32", "base32", "base64", "sha1"]
+v2 = ["rsa", "rand", "base32", "base32", "base64", "sha1"]
 v3 = ["rand", "ed25519-dalek", "base32", "base64", "sha3"]
 
 [badges]
@@ -27,8 +27,7 @@ serde_derive = { version = "1.0", optional = true }
 
 derive_more = "0.15.0"
 
-# TODO(teawithsand): replace this with RSA crate, which is rust one and should provide better portability
-openssl = { version="0.10", optional = true }
+rsa = { version = "0.3", optional = true }
 
 sha3 = { version = "0.8", optional = true } # for onion service v3 signature
 sha2 = { version = "0.8", optional = true } # for ed25519-dalek key
@@ -38,7 +37,7 @@ hmac = { version = "0.7", optional = true } # for authentication with tor contro
 # ed25519-dalek = { git = "https://github.com/dalek-cryptography/ed25519-dalek", branch="master", optional = true }
 # Migrate to https://crates.io/crates/ed25519?
 
-ed25519-dalek = { version = "1.0.0-pre.3", optional = true }
+ed25519-dalek = { version = "1.0", optional = true }
 rand = { version = "0.7", optional = true }
 base32 = { version = "0.4", optional = true }
 base64 = { version = "0.10", optional = true }

--- a/src/onion/v2/serde.rs
+++ b/src/onion/v2/serde.rs
@@ -35,9 +35,7 @@ impl<'de> Deserialize<'de> for TorSecretKeyV2 {
         let raw = RSAPrivateKey::from_pkcs1(text.as_bytes())
             .or_else(|_| RSAPrivateKey::from_pkcs8(text.as_bytes()))
             .map_err(serde::de::Error::custom)?;
-        if !raw.check_key().map_err(serde::de::Error::custom)? {
-            return Err(serde::de::Error::custom("RSA key invalid"));
-        }
+        raw.validate().map_err(serde::de::Error::custom)?;
         Ok(TorSecretKeyV2(raw))
     }
 }


### PR DESCRIPTION
Sharing my initial work on replacing OpenSSL with RSA, blocked by required upstream changes.

Right now fails to compile because it requires key encoding functions (analogs for OpenSSL's `private_key_to_der`, `private_key_to_pem`) currently absent in RSA crate.

Also, since RSA crate is experimental, thinking of adding it as a feature, so users may choose between OpenSSL and RSA