### PR TITLE
Feature flag TorSecretKey and OnionAddress. 

### DIFF
--- a/src/onion/common.rs
+++ b/src/onion/common.rs
@@ -8,14 +8,18 @@ use crate::onion::{OnionAddressV3, TorPublicKeyV3, TorSecretKeyV3};
 #[derive(Debug, Clone, PartialEq, Eq, From, TryInto)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum TorSecretKey {
+    #[cfg(feature = "v2")]
     V2(TorSecretKeyV2),
+    #[cfg(feature = "v3")]
     V3(TorSecretKeyV3),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, From, TryInto)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum OnionAddress {
+    #[cfg(feature = "v2")]
     V2(OnionAddressV2),
+    #[cfg(feature = "v3")]
     V3(OnionAddressV3),
 }
 


### PR DESCRIPTION
Building without v2/v3 feature flag failed because the enum variants needed certain structs which were already feature-flagged. 
