### PR TITLE
Fix issue with '$' in parse_single_key_value

### DIFF
--- a/src/utils/key_value.rs
+++ b/src/utils/key_value.rs
@@ -22,7 +22,7 @@ pub fn parse_key_value() {}
 /// # Error
 /// It returns an error:
 /// - if there is no equal sign
-/// - if data before equal sign is not `A-Za-z0-9_ -/` ascii chars(notice space character)
+/// - if data before equal sign is not `A-Za-z0-9_ -/$` ascii chars(notice space character)
 /// - if value as quoted string enclosing quote is not last character of text
 ///
 /// It *does not* return an error when key value is empty string so format is: `="asdf"`
@@ -44,7 +44,7 @@ pub fn parse_single_key_value(text: &str) -> Result<(&str, &str), ()>
         if c == '=' {
             break;
         }
-        if c != ' ' && c != '-' && c != '_' && c != '/' && !c.is_ascii_alphanumeric() {
+        if c != ' ' && c != '-' && c != '_' && c != '/' && c != '$' && !c.is_ascii_alphanumeric() {
             return Err(());
         }
         key_offset += c.len_utf8();


### PR DESCRIPTION
When issuing the following command:
```
GETINFO ns/id/$some_fingerprint
```

The Tor control socket returns a response like:
```
250+ns/id/$some_fingerprint=\r\n
r nickname identity digest ... \r\n
[...] \r\n
\r\n
250 OK\r\n
```

But we got the error `ConnError::InvalidFormat` because
`parse_single_key_value` does not include '$' as a valid character in
the key part.