### PR TITLE
Change tokio version to 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ base32 = { version = "0.4", optional = true }
 base64 = { version = "0.10", optional = true }
 hex = { version = "0.4", optional = true }
 
-tokio = { version = "1.7", features = ["io-util"], optional = true }
+tokio = { version = "1", features = ["io-util"], optional = true }
 
 # for fuzzing right now
 # TODO(reawithsand): fix it somehow
@@ -49,4 +49,4 @@ tokio = { version = "1.7", features = ["io-util"], optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"
-tokio = { version = "1.4", features = ["full"] }
+tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
When cargo does version resolution with dependencies that have a
major version >= 1, it doesn't actually respect the minor version
that is set in this manifest file.

Reference: https://doc.rust-lang.org/cargo/reference/resolver.html#semver-compatibility