### PR TITLE
Update/dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,11 @@ maintenance = { status = "passively-maintained" }
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 
-derive_more = "0.15.0"
+derive_more = "0.99.16"
 
 openssl = { version = "0.10", optional = true }
 
-sha3 = { version = "0.8", optional = true } # for onion service v3 signature
+sha3 = { version = "0.9.1", optional = true } # for onion service v3 signature
 sha2 = { version = "0.9.5", optional = true } # for ed25519-dalek key
 sha1 = { version = "0.6", optional = true } # for onion service v2 signature
 hmac = { version = "0.11.0", optional = true } # for authentication with tor controller
@@ -38,7 +38,7 @@ hmac = { version = "0.11.0", optional = true } # for authentication with tor con
 ed25519-dalek = { version = "1.0", optional = true }
 rand = { version = "0.7", optional = true }
 base32 = { version = "0.4", optional = true }
-base64 = { version = "0.10", optional = true }
+base64 = { version = "0.13", optional = true }
 hex = { version = "0.4", optional = true }
 
 tokio = { version = "1", features = ["io-util"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,9 @@ derive_more = "0.15.0"
 openssl = { version = "0.10", optional = true }
 
 sha3 = { version = "0.8", optional = true } # for onion service v3 signature
-sha2 = { version = "0.8", optional = true } # for ed25519-dalek key
+sha2 = { version = "0.9.5", optional = true } # for ed25519-dalek key
 sha1 = { version = "0.6", optional = true } # for onion service v2 signature
-hmac = { version = "0.7", optional = true } # for authentication with tor controller
+hmac = { version = "0.11.0", optional = true } # for authentication with tor controller
 
 ed25519-dalek = { version = "1.0", optional = true }
 rand = { version = "0.7", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ derive_more = "0.99.16"
 
 openssl = { version = "0.10", optional = true }
 
-sha3 = { version = "0.9.1", optional = true } # for onion service v3 signature
-sha2 = { version = "0.9.5", optional = true } # for ed25519-dalek key
+sha3 = { version = "0.9", optional = true } # for onion service v3 signature
+sha2 = { version = "0.9", optional = true } # for ed25519-dalek key
 sha1 = { version = "0.6", optional = true } # for onion service v2 signature
 hmac = { version = "0.11.0", optional = true } # for authentication with tor controller
 

--- a/src/control/conn/unauthenticated_conn.rs
+++ b/src/control/conn/unauthenticated_conn.rs
@@ -296,7 +296,7 @@ impl<S> UnauthenticatedConn<S>
                 //  or some wild hacks like comparing sha256 hashes of both values(which leaks hashes values but not values itself)
 
                 let client_hash = {
-                    let mut hmac = <Hmac<Sha256>>::new_varkey(TOR_SAFECOOKIE_CONSTANT)
+                    let mut hmac = <Hmac<Sha256>>::new_from_slice(TOR_SAFECOOKIE_CONSTANT)
                         .expect("Any key len for hmac should be valid. If it's not then rehash data. Right?");
                     hmac.input(cookie.as_ref());
                     hmac.input(&client_nonce[..]);

--- a/src/onion/v3/key.rs
+++ b/src/onion/v3/key.rs
@@ -1,5 +1,5 @@
 use ed25519_dalek::{ExpandedSecretKey, PublicKey, SecretKey, SignatureError};
-use rand::thread_rng;
+use rand::{Rng, thread_rng};
 use crate::onion::OnionAddressV3;
 
 use crate::utils::BASE32_ALPHA;

--- a/src/onion/v3/onion.rs
+++ b/src/onion/v3/onion.rs
@@ -41,11 +41,11 @@ impl From<&TorPublicKeyV3> for OnionAddressV3 {
         });
 
         let mut h = sha3::Sha3_256::new();
-        h.input(b".onion checksum");
-        h.input(&tpk.0);
-        h.input(b"\x03");
+        h.update(b".onion checksum");
+        h.update(&tpk.0);
+        h.update(b"\x03");
 
-        let res_vec = h.result().to_vec();
+        let res_vec = h.finalize().to_vec();
         buf[32] = res_vec[0];
         buf[33] = res_vec[1];
         Self(buf)
@@ -155,11 +155,11 @@ impl FromStr for OnionAddressV3 {
         //  where H is sha3_256
 
         let mut h = sha3::Sha3_256::new();
-        h.input(b".onion checksum");
-        h.input(&res[..32]);
-        h.input(b"\x03");
+        h.update(b".onion checksum");
+        h.update(&res[..32]);
+        h.update(b"\x03");
 
-        let res_vec = h.result().to_vec();
+        let res_vec = h.finalize().to_vec();
         if res_vec[0] != res[32] || res_vec[1] != res[33] {
             return Err(OnionAddressParseError::InvalidChecksum);
         }


### PR DESCRIPTION
The main motivation for these changes is due to the fact that `crypto-mac = "^0.7"` seems to have been yanked from crates.io, which `hmac v0.7.0` depended on. Updating hmac to latest resolved the dependency issue. The api did change in this version, however, so fixes implemented. Non Tor tests pass, could not get Tor tests to work with env:
```
Tor version 0.4.6.7.
Tor is running on Darwin with Libevent 2.1.12-stable, OpenSSL 1.1.1k, Zlib 1.2.11, Liblzma N/A, Libzstd N/A and Unknown N/A as libc.
Tor compiled with clang version 12.0.0
```

Let me know if there is anything else that should be addressed. 